### PR TITLE
Renamed Popover component to Popout and updated skills and about me section

### DIFF
--- a/apps/portfolio/src/components/About.tsx
+++ b/apps/portfolio/src/components/About.tsx
@@ -1,6 +1,5 @@
 import type { FC } from 'react';
-import { motion } from 'framer-motion';
-import { Popover } from '@chadlefort/ui';
+import { Popout } from '@chadlefort/ui';
 
 export const About: FC = () => {
   return (
@@ -12,34 +11,19 @@ export const About: FC = () => {
         {Array(5)
           .fill(null)
           .map((_, index) => (
-            <Popover
+            <Popout
               key={`about-${index}`}
               id={`about-${index}`}
               renderPopoverContent={() => (
                 <img src={`about/about-${index + 1}.png`} alt="Chad Lefort" className="rounded-2xl" />
               )}
             >
-              <motion.div initial="offscreen" whileInView="onscreen" viewport={{ once: true, amount: 0.8 }}>
-                <motion.img
-                  variants={{
-                    offscreen: {
-                      y: 300,
-                    },
-                    onscreen: {
-                      y: 0,
-                      transition: {
-                        type: 'spring',
-                        bounce: 0.2,
-                        duration: 1,
-                      },
-                    },
-                  }}
-                  src={`about/about-${index + 1}.png`}
-                  alt="Chad Lefort"
-                  className="m-4 max-h-44 max-w-44 rounded-2xl object-contain"
-                />
-              </motion.div>
-            </Popover>
+              <img
+                src={`about/about-${index + 1}.png`}
+                alt="Chad Lefort"
+                className="m-4 max-h-44 max-w-44 rounded-2xl object-contain"
+              />
+            </Popout>
           ))}
       </div>
 

--- a/apps/portfolio/src/components/Skills.tsx
+++ b/apps/portfolio/src/components/Skills.tsx
@@ -1,16 +1,27 @@
 import { Card, CardIcon, Link } from '@chadlefort/ui';
 import {
   SiJavascript,
+  SiJavascriptHex,
   SiMockserviceworker,
+  SiMockserviceworkerHex,
   SiNodedotjs,
+  SiNodedotjsHex,
   SiNuxtdotjs,
+  SiNuxtdotjsHex,
   SiReact,
+  SiReactHex,
   SiRedux,
+  SiReduxHex,
   SiTestinglibrary,
+  SiTestinglibraryHex,
   SiTypescript,
+  SiTypescriptHex,
   SiVite,
+  SiViteHex,
   SiVitest,
+  SiVitestHex,
   SiVuedotjs,
+  SiVuedotjsHex,
 } from '@icons-pack/react-simple-icons';
 import type { FC } from 'react';
 import clsx from 'clsx';
@@ -25,52 +36,132 @@ export const Skills: FC = () => {
 
       <Card className="w-fit self-center p-6">
         <div className="flex flex-wrap justify-center gap-6">
-          <Link href="https://reactjs.org/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiReact} title="React" className={clsx('bg-[#61DAFB]', baseIconCardClass)} />
-          </Link>
-
-          <Link href="https://redux.js.org/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiRedux} title="Redux" className={clsx('bg-[#764ABC]', baseIconCardClass)} />
-          </Link>
-
-          <Link href="https://www.typescriptlang.org/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiTypescript} title="TypeScript" className={clsx('bg-[#3178C6]', baseIconCardClass)} />
+          <Link
+            animate
+            href="https://reactjs.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon icon={SiReact} title="React" className={clsx(`bg-[${SiReactHex}]`, baseIconCardClass)} />
           </Link>
 
           <Link
+            animate
+            href="https://redux.js.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon icon={SiRedux} title="Redux" className={clsx(`bg-[${SiReduxHex}]`, baseIconCardClass)} />
+          </Link>
+
+          <Link
+            animate
+            href="https://www.typescriptlang.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon
+              icon={SiTypescript}
+              title="TypeScript"
+              className={clsx(`bg-[${SiTypescriptHex}]`, baseIconCardClass)}
+            />
+          </Link>
+
+          <Link
+            animate
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript"
             target="_blank"
             rel="noopener noreferrer"
+            className="hover:text-white"
           >
-            <CardIcon icon={SiJavascript} title="JavaScript" className={clsx('bg-[#F7DF1E]', baseIconCardClass)} />
+            <CardIcon
+              icon={SiJavascript}
+              title="JavaScript"
+              className={clsx(`bg-[${SiJavascriptHex}]`, baseIconCardClass)}
+            />
           </Link>
 
-          <Link href="https://vuejs.org/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiVuedotjs} title="Vue.js" className={clsx('bg-[#4FC08D]', baseIconCardClass)} />
+          <Link
+            animate
+            href="https://vuejs.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon icon={SiVuedotjs} title="Vue.js" className={clsx(`bg-[${SiVuedotjsHex}]`, baseIconCardClass)} />
           </Link>
 
-          <Link href="https://nuxtjs.org/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiNuxtdotjs} title="Nuxt.js" className={clsx('bg-[#00DC82]', baseIconCardClass)} />
+          <Link
+            animate
+            href="https://nuxtjs.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon
+              icon={SiNuxtdotjs}
+              title="Nuxt.js"
+              className={clsx(`bg-[${SiNuxtdotjsHex}]`, baseIconCardClass)}
+            />
           </Link>
 
-          <Link href="https://vitejs.dev/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiVite} title="Vite" className={clsx('bg-[#646CFF]', baseIconCardClass)} />
+          <Link
+            animate
+            href="https://vitejs.dev/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon icon={SiVite} title="Vite" className={clsx(`bg-[${SiViteHex}]`, baseIconCardClass)} />
           </Link>
 
-          <Link href="https://vitest.dev/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiVitest} title="Vitest" className={clsx('bg-[#6E9F18]', baseIconCardClass)} />
+          <Link
+            animate
+            href="https://vitest.dev/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon icon={SiVitest} title="Vitest" className={clsx(`bg-[${SiVitestHex}]`, baseIconCardClass)} />
           </Link>
 
-          <Link href="https://testing-library.com/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiTestinglibrary} title="Testing Lib" className={clsx('bg-[#E33332]', baseIconCardClass)} />
+          <Link
+            animate
+            href="https://testing-library.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon
+              icon={SiTestinglibrary}
+              title="Testing Lib"
+              className={clsx(`bg-[${SiTestinglibraryHex}]`, baseIconCardClass)}
+            />
           </Link>
 
-          <Link href="https://mswjs.io/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiMockserviceworker} title="MSW" className={clsx('bg-[#FF6A33]', baseIconCardClass)} />
+          <Link animate href="https://mswjs.io/" target="_blank" rel="noopener noreferrer" className="hover:text-white">
+            <CardIcon
+              icon={SiMockserviceworker}
+              title="MSW"
+              className={clsx(`bg-[${SiMockserviceworkerHex}]`, baseIconCardClass)}
+            />
           </Link>
 
-          <Link href="https://nodejs.org/" target="_blank" rel="noopener noreferrer">
-            <CardIcon icon={SiNodedotjs} title="Node.js" className={clsx('bg-[#5FA04E]', baseIconCardClass)} />
+          <Link
+            animate
+            href="https://nodejs.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-white"
+          >
+            <CardIcon
+              icon={SiNodedotjs}
+              title="Node.js"
+              className={clsx(`bg-[${SiNodedotjsHex}]`, baseIconCardClass)}
+            />
           </Link>
         </div>
       </Card>

--- a/packages/ui/src/components/CardIcon.tsx
+++ b/packages/ui/src/components/CardIcon.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 import { useState } from 'react';
 import clsx from 'clsx';
-import { motion } from 'framer-motion';
 import { tv } from 'tailwind-variants';
 
 import type { Icon } from './Button';
@@ -25,15 +24,14 @@ export const CardIcon: FC<CardProps> = ({ children, className, icon, title }) =>
   const [isHovered, setIsHovered] = useState(false);
 
   return (
-    <motion.div
-      whileHover={{ scale: 1.2 }}
-      onHoverStart={() => setIsHovered(true)}
-      onHoverEnd={() => setIsHovered(false)}
+    <div
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
       className={clsx(cardIcon(), className)}
     >
       {!isHovered && <Icon className="size-8" />}
       {isHovered && title && <h1 className="text-xs font-semibold">{title}</h1>}
       {children}
-    </motion.div>
+    </div>
   );
 };

--- a/packages/ui/src/components/Link.tsx
+++ b/packages/ui/src/components/Link.tsx
@@ -9,8 +9,9 @@ import { focusRing } from '../utils';
 
 export type LinkProps = {
   variant?: 'primary' | 'secondary';
-  animated?: boolean;
-};
+  animate?: boolean;
+} & RACLinkProps &
+  Omit<MotionProps, 'animate'>;
 
 const link = tv({
   extend: focusRing,
@@ -28,8 +29,8 @@ const link = tv({
 
 const AnimatedLink = motion(RACLink);
 
-export const Link: FC<LinkProps & RACLinkProps & MotionProps> = (props) => {
-  return props.animated ? (
+export const Link: FC<LinkProps> = (props) => {
+  return props.animate ? (
     <AnimatedLink
       {...props}
       whileHover={{ scale: !props.isDisabled ? 1.4 : undefined }}

--- a/packages/ui/src/components/Popout.stories.tsx
+++ b/packages/ui/src/components/Popout.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Popover } from './Popover';
+import { Popout } from './Popout';
 import { Card } from './Card';
 
-const meta: Meta<typeof Popover> = {
-  title: 'Popover',
-  component: Popover,
+const meta: Meta<typeof Popout> = {
+  title: 'Popout',
+  component: Popout,
   argTypes: {
     showCloseButton: {
       control: 'boolean',
@@ -16,13 +16,13 @@ const meta: Meta<typeof Popover> = {
   },
   render: (args) => (
     <div className="flex h-screen items-center justify-center">
-      <Popover {...args} />
+      <Popout {...args} />
     </div>
   ),
 };
 
 export default meta;
-type Story = StoryObj<typeof Popover>;
+type Story = StoryObj<typeof Popout>;
 
 export const Default: Story = {
   args: {
@@ -39,7 +39,7 @@ export const WithCloseButton: Story = {
     showCloseButton: true,
     renderPopoverContent: () => (
       <Card className="p-6">
-        <p className="mt-6">Popover content</p>
+        <p className="mt-6">Popout content</p>
       </Card>
     ),
   },

--- a/packages/ui/src/components/Popout.tsx
+++ b/packages/ui/src/components/Popout.tsx
@@ -5,14 +5,14 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 
 import { Button } from './Button';
 
-type PopoverProps = {
+type PopoutProps = {
   id: string;
   renderPopoverContent: () => React.ReactNode;
   children: React.ReactNode;
   showCloseButton?: boolean;
 };
 
-export const Popover: FC<PopoverProps> = ({ id, children, renderPopoverContent, showCloseButton }) => {
+export const Popout: FC<PopoutProps> = ({ id, children, renderPopoverContent, showCloseButton }) => {
   const [selected, setSelected] = useState(false);
 
   useEffect(() => {
@@ -51,7 +51,7 @@ export const Popover: FC<PopoverProps> = ({ id, children, renderPopoverContent, 
   );
 };
 
-type PopoverContentProps = {
+type PopoutContentProps = {
   id: string;
   selected: boolean;
   setSelected: (selected: boolean) => void;
@@ -59,7 +59,7 @@ type PopoverContentProps = {
   showCloseButton?: boolean;
 };
 
-const PopoverContent: FC<PopoverContentProps> = ({ id, selected, setSelected, children, showCloseButton }) => {
+const PopoverContent: FC<PopoutContentProps> = ({ id, selected, setSelected, children, showCloseButton }) => {
   const handleClose = () => setSelected(false);
 
   return (
@@ -72,7 +72,7 @@ const PopoverContent: FC<PopoverContentProps> = ({ id, selected, setSelected, ch
           exit={{ opacity: 0 }}
           onClick={handleClose}
         >
-          <div className="relative px-4">
+          <div className="relative">
             <motion.div
               className="max-w-auto mx-auto md:max-w-6xl"
               layoutId={`card-container-${id}`}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,7 @@ export * from './components/Avatar';
 export * from './components/Terminal';
 export * from './components/Menu';
 export * from './components/Card';
-export * from './components/Popover';
+export * from './components/Popout';
 export * from './components/CardIcon';
 export * from './components/Link';
 export * from './components/Timeline';


### PR DESCRIPTION
Renamed Popover component to Popout. This makes more sense due to the functionality of the component.

Reworked skills section to use imported hex codes for brand colors and wrapped each skill in an animated link for consistent animations with other links.

Removed animations from about me section's images as it felt like too many animations were happening on the page.